### PR TITLE
feat: Refactor backtest workflow to run full strategy × risk level ma…

### DIFF
--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -26,10 +26,8 @@ jobs:
         run: |
           if [ "${{ github.ref_name }}" = "dev" ]; then
             echo "branch=int" >> "$GITHUB_OUTPUT"
-            echo "label=promote:dev→int" >> "$GITHUB_OUTPUT"
           elif [ "${{ github.ref_name }}" = "int" ]; then
             echo "branch=main" >> "$GITHUB_OUTPUT"
-            echo "label=promote:int→prod" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Create or update promotion PR
@@ -38,7 +36,12 @@ jobs:
         run: |
           SOURCE="${{ github.ref_name }}"
           TARGET="${{ steps.target.outputs.branch }}"
-          LABEL="${{ steps.target.outputs.label }}"
+
+          # Check if there are any differences between source and target
+          if git diff --quiet "origin/$TARGET"..."origin/$SOURCE" 2>/dev/null; then
+            echo "No differences between $SOURCE and $TARGET — nothing to promote"
+            exit 0
+          fi
 
           # Check if a promotion PR already exists
           EXISTING=$(gh pr list --base "$TARGET" --head "$SOURCE" --json number --jq '.[0].number // empty')
@@ -46,10 +49,10 @@ jobs:
           if [ -n "$EXISTING" ]; then
             echo "Promotion PR #$EXISTING already exists ($SOURCE → $TARGET)"
           else
+            echo "Creating promotion PR: $SOURCE → $TARGET"
             gh pr create \
               --base "$TARGET" \
               --head "$SOURCE" \
               --title "Promote $SOURCE → $TARGET" \
-              --body "Automated promotion PR. Merging this promotes all changes from \`$SOURCE\` to \`$TARGET\`." \
-              --label "$LABEL" || echo "No new commits to promote"
+              --body "Automated promotion PR. Merging this promotes all changes from \`$SOURCE\` to \`$TARGET\`."
           fi


### PR DESCRIPTION
…… (#69)

feat: Refactor backtest workflow to run full strategy × risk level matrix and post results as PR comment

## Summary

<!-- Brief description of what this PR does and why -->

## Changes

-

## Target Branch

<!-- Which environment branch is this PR targeting? -->

- [ ] `dev` — development (mock API, paper mode)
- [ ] `int` — integration/staging (real API, paper mode)
- [ ] `main` — production (real API, live mode)

## Test Plan

- [ ] Tests pass locally (`make test`)
- [ ] Lint passes (`make lint`)
- [ ] Type check passes (`make typecheck`)
- [ ] Documentation updated (if applicable)

## Related Issues

<!-- Closes #123 -->
