### PR TITLE
Potential fix for code scanning alert no. 2: Clear-text logging of sensitive information

### DIFF
--- a/cli/revt.py
+++ b/cli/revt.py
@@ -628,7 +628,7 @@ def _ops_show(env: str) -> None:
         "--reveal",
     )
     if r.returncode == 0:
-        print(f"  {'TELEGRAM_BOT_TOKEN':<28}  {_mask_secret(r.stdout.strip())}")
+        print(f"  {'TELEGRAM_BOT_TOKEN':<28}  <stored in 1Password (hidden)>")
 
     print(f"\n=== Configuration  ({_op_config_item(env)}) ===\n")
     print(f"  {'TRADING_MODE':<28}  (derived: dev/int → paper, prod → live)")


### PR DESCRIPTION
Potential fix for [https://github.com/badoriie/revolut-trader/security/code-scanning/2](https://github.com/badoriie/revolut-trader/security/code-scanning/2)

In general, to fix clear‑text logging issues, ensure that any data derived from secrets is either (a) not logged at all, or (b) reduced to a strictly non-sensitive representation (e.g., fixed string, irreversible hash, or heavily redacted form that reveals zero or at most a tiny, policy-approved portion). Relying on ad‑hoc masking utilities that may leave parts of the secret visible can still violate security requirements and trigger static analyzers.

The minimal, behavior-preserving fix here is to change the output for `TELEGRAM_BOT_TOKEN` so that it never includes any part of the actual token. Other credentials in `_ops_show` are already being “masked” via `_mask_secret`, but CodeQL only flagged the specific line for `TELEGRAM_BOT_TOKEN`. We can replace the call to `_mask_secret(r.stdout.strip())` for this field with a constant, non-sensitive placeholder such as `"<stored in 1Password (hidden)>"`. This way, users still see that a Telegram bot token exists and is configured, but they never see the token’s value. No imports or new functions are required; we only adjust the f-string at line 631 in `cli/revt.py`.

Concretely:
- In `cli/revt.py`, within `_ops_show`, locate the `if r.returncode == 0:` block following retrieval of `TELEGRAM_BOT_TOKEN`.
- Replace the `print` that currently uses `_mask_secret(r.stdout.strip())` with a `print` that uses a constant string in place of the masked secret.
- No changes are needed elsewhere, and we don’t have to modify `_mask_secret` or its other call sites.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
