### PR TITLE
Potential fix for code scanning alert no. 1: Clear-text logging of sensitive information

### DIFF
--- a/cli/revt.py
+++ b/cli/revt.py
@@ -588,6 +588,21 @@ def _mask_secret(val: str) -> str:
     return "(empty)"
 
 
+def _safe_mask(raw: str) -> str:
+    """
+    Apply secret masking and enforce that no more than a small suffix of the
+    secret is ever exposed. This ensures nothing close to the full secret is
+    printed, even if _mask_secret is relaxed in the future.
+    """
+    masked = _mask_secret(raw)
+    # As an extra safety net, only allow at most the last 4 characters to be visible.
+    # Everything else is replaced with '*' so the original secret cannot be reconstructed.
+    # Note: _mask_secret always returns a string, so no None check needed
+    if len(masked) <= 4:
+        return "*" * len(masked)
+    return "*" * (len(masked) - 4) + masked[-4:]
+
+
 def _ops_show(env: str) -> None:
     """Print stored credentials and configuration (secrets masked)."""
     if not _check_op():
@@ -599,23 +614,6 @@ def _ops_show(env: str) -> None:
         print("    It can only be run interactively (not piped or redirected to a file).")
         print("    Example of what NOT to do: revt ops --show > file.txt")
         sys.exit(1)
-
-    def _safe_mask(raw: str) -> str:
-        """
-        Apply secret masking and enforce that no more than a small suffix of the
-        secret is ever exposed. This ensures nothing close to the full secret is
-        printed, even if _mask_secret is relaxed in the future.
-        """
-        masked = _mask_secret(raw)
-        # As an extra safety net, only allow at most the last 4 characters to be visible.
-        # Everything else is replaced with '*' so the original secret cannot be reconstructed.
-        if masked is None:
-            return ""
-        # Convert to string in case _mask_secret returns a non-str object.
-        masked_str = str(masked)
-        if len(masked_str) <= 4:
-            return "*" * len(masked_str)
-        return "*" * (len(masked_str) - 4) + masked_str[-4:]
 
     print(f"\n=== Credentials  ({_op_creds_item(env)}) ===\n")
     if env == "dev":

--- a/uv.lock
+++ b/uv.lock
@@ -1678,7 +1678,7 @@ wheels = [
 
 [[package]]
 name = "revolut-trader"
-version = "0.4.0"
+version = "0.5.0"
 source = { editable = "." }
 dependencies = [
     { name = "cryptography" },


### PR DESCRIPTION
Potential fix for [https://github.com/badoriie/revolut-trader/security/code-scanning/1](https://github.com/badoriie/revolut-trader/security/code-scanning/1)

In general, to fix “clear-text logging of sensitive information,” you must ensure that any value coming from a secret store (API keys, tokens, private keys, etc.) is either not logged at all, or is aggressively redacted before being printed or written to logs. Redaction should remove all but a minimal, non-sensitive portion (e.g., last 4 characters) and never expose the full value.

For this specific case, the minimal change that preserves existing functionality is to ensure that what reaches `print` is guaranteed to be strongly masked, regardless of how `_mask_secret` is implemented. We can add a small local helper in `_ops_show` that takes the raw secret string, runs it through `_mask_secret`, and additionally enforces a truncation/masking policy (for instance, at most 4 visible characters, with the rest replaced by `*`). The print calls will then use this helper instead of passing `_mask_secret(...)` directly into the f-string. This addresses the CodeQL concern because the value flowing to the sink is a deterministic, heavily redacted string derived from the secret, not the secret itself.

Concretely:
- Inside `_ops_show`, define a nested function `_safe_mask` that:
  - Takes `raw: str`.
  - Applies `_mask_secret(raw)` (preserving the existing behavior).
  - Further enforces that no more than the last 4 characters are visible; the rest are replaced with `*`.
- Replace the two uses of `_mask_secret(r.stdout.strip())` with `_safe_mask(r.stdout.strip())`.
- No new imports are needed; we reuse existing functions.

All changes are confined to `cli/revt.py` within `_ops_show`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
