### PR TITLE
feat(backtest): add --real-data flag to run real-API backtests from a…

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,8 +7,8 @@
 ```bash
 # Development
 just install | test | lint | format | typecheck | security | check | clean
-just backtest-dev   # matrix (7d, mock API — feature branches)
-just backtest-int   # matrix (30d, real API — main branch)
+just backtest       # matrix (7d, mock API — any branch)
+just backtest-int   # matrix (30d, real API — any branch, requires int credentials)
 
 # Trading bot
 revt run [--strategy S] [--risk R] [--mode live] [--confirm-live]

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,8 +7,8 @@
 ```bash
 # Development
 just install | test | lint | format | typecheck | security | check | clean
-just backtest       # matrix (7d, mock API — any branch)
-just backtest-int   # matrix (30d, real API — any branch, requires int credentials)
+just backtest            # matrix (7d, mock API — any branch)
+just backtest-real-data  # matrix (7d, real API — any branch, requires int credentials)
 
 # Trading bot
 revt run [--strategy S] [--risk R] [--mode live] [--confirm-live]

--- a/README.md
+++ b/README.md
@@ -357,8 +357,8 @@ just typecheck        # pyright src/ cli/
 just check            # all of the above + tests
 just pre-commit       # run all pre-commit hooks
 just clean            # remove cache files
-just backtest         # matrix backtest, 7d mock API (any branch)
-just backtest-int     # matrix backtest, 30d real API (any branch, requires int credentials)
+just backtest              # matrix backtest, 7d mock API (any branch)
+just backtest-real-data    # matrix backtest, 7d real API (any branch, requires int credentials)
 just --list           # show all available commands
 ```
 

--- a/README.md
+++ b/README.md
@@ -357,8 +357,8 @@ just typecheck        # pyright src/ cli/
 just check            # all of the above + tests
 just pre-commit       # run all pre-commit hooks
 just clean            # remove cache files
-just backtest-dev     # matrix backtest, 7d mock API (feature branches)
-just backtest-int     # matrix backtest, 30d real API (main branch)
+just backtest         # matrix backtest, 7d mock API (any branch)
+just backtest-int     # matrix backtest, 30d real API (any branch, requires int credentials)
 just --list           # show all available commands
 ```
 

--- a/cli/commands/backtest.py
+++ b/cli/commands/backtest.py
@@ -45,7 +45,8 @@ async def run_backtest(args) -> None:
     effective_days = args.days if args.days is not None else settings.backtest_days
     effective_interval = args.interval if args.interval is not None else settings.backtest_interval
 
-    api_client = create_api_client(settings.environment)
+    real_data = getattr(args, "real_data", False)
+    api_client = create_api_client(settings.environment, force_real=real_data)
     await api_client.initialize()
 
     engine = BacktestEngine(

--- a/cli/commands/backtest.py
+++ b/cli/commands/backtest.py
@@ -16,7 +16,7 @@ from cli.utils.env_detect import set_env as _set_env
 
 _set_env()
 
-from src.api import create_api_client
+from cli.utils.backtest_args import create_backtest_api_client, resolve_backtest_params
 from src.backtest.engine import BacktestEngine
 from src.config import RiskLevel, StrategyType, settings
 from src.utils.db_persistence import DatabasePersistence
@@ -37,16 +37,13 @@ async def run_backtest(args) -> None:
     # CLI flags override 1Password settings; fall back to 1Password values when not given.
     strategy_type = StrategyType(args.strategy or settings.default_strategy.value)
     risk_level = RiskLevel(args.risk or settings.risk_level.value)
-    raw_pairs = args.pairs if args.pairs else ",".join(settings.trading_pairs)
-    symbols = raw_pairs.split(",")
-    initial_capital = Decimal(
-        str(args.capital if args.capital is not None else settings.paper_initial_capital)
-    )
-    effective_days = args.days if args.days is not None else settings.backtest_days
-    effective_interval = args.interval if args.interval is not None else settings.backtest_interval
+    params = resolve_backtest_params(args)
+    symbols = params["symbols"]
+    initial_capital: Decimal = params["initial_capital"]
+    effective_days: int = params["effective_days"]
+    effective_interval: int = params["effective_interval"]
 
-    real_data = getattr(args, "real_data", False)
-    api_client = create_api_client(settings.environment, force_real=real_data)
+    api_client = create_backtest_api_client(args)
     await api_client.initialize()
 
     engine = BacktestEngine(

--- a/cli/commands/backtest_compare.py
+++ b/cli/commands/backtest_compare.py
@@ -27,7 +27,7 @@ from cli.utils.env_detect import set_env as _set_env
 
 _set_env()
 
-from src.api import create_api_client
+from cli.utils.backtest_args import create_backtest_api_client, resolve_backtest_params
 from src.backtest.engine import BacktestEngine, BacktestResults
 from src.config import RiskLevel, StrategyType, settings
 from src.utils.db_persistence import DatabasePersistence
@@ -193,16 +193,13 @@ async def run_compare(args) -> None:
     strategies = args.strategies.split(",") if args.strategies else ALL_STRATEGIES
     effective_risk = args.risk or settings.risk_level.value
     risk_levels = args.risk_levels.split(",") if args.risk_levels else [effective_risk]
-    raw_pairs = args.pairs if args.pairs else ",".join(settings.trading_pairs)
-    symbols = raw_pairs.split(",")
-    initial_capital = Decimal(
-        str(args.capital if args.capital is not None else settings.paper_initial_capital)
-    )
-    effective_days = args.days if args.days is not None else settings.backtest_days
-    effective_interval = args.interval if args.interval is not None else settings.backtest_interval
+    params = resolve_backtest_params(args)
+    symbols = params["symbols"]
+    initial_capital: Decimal = params["initial_capital"]
+    effective_days: int = params["effective_days"]
+    effective_interval: int = params["effective_interval"]
 
-    real_data = getattr(args, "real_data", False)
-    api_client = create_api_client(settings.environment, force_real=real_data)
+    api_client = create_backtest_api_client(args)
     await api_client.initialize()
     db = DatabasePersistence()
 

--- a/cli/commands/backtest_compare.py
+++ b/cli/commands/backtest_compare.py
@@ -201,7 +201,8 @@ async def run_compare(args) -> None:
     effective_days = args.days if args.days is not None else settings.backtest_days
     effective_interval = args.interval if args.interval is not None else settings.backtest_interval
 
-    api_client = create_api_client(settings.environment)
+    real_data = getattr(args, "real_data", False)
+    api_client = create_api_client(settings.environment, force_real=real_data)
     await api_client.initialize()
     db = DatabasePersistence()
 
@@ -381,6 +382,7 @@ def run_compare_cli(
     interval: int | None = None,
     capital: float | None = None,
     log_level: str | None = None,
+    real_data: bool = False,
 ) -> None:
     """Run comparison backtest with the given parameters.
 
@@ -396,6 +398,7 @@ def run_compare_cli(
         interval: Candle interval in minutes.
         capital: Initial capital in EUR.
         log_level: Logging level (DEBUG, INFO, WARNING, ERROR).
+        real_data: If True, use the real API client even on a dev branch.
     """
     from types import SimpleNamespace
 
@@ -411,6 +414,7 @@ def run_compare_cli(
         interval=interval,
         capital=capital,
         log_level=log_level,
+        real_data=real_data,
     )
 
     try:

--- a/cli/revt.py
+++ b/cli/revt.py
@@ -414,6 +414,8 @@ def cmd_backtest(args: argparse.Namespace) -> None:
     logger.remove()
     logger.add(sys.stderr, level=args.log_level or "INFO")
 
+    real_data = getattr(args, "real_data", False)
+
     if args.matrix:
         print("\n  STRATEGY × RISK LEVEL MATRIX BACKTEST\n")
         _run_compare_cli(
@@ -425,6 +427,7 @@ def cmd_backtest(args: argparse.Namespace) -> None:
             risk_levels="conservative,moderate,aggressive",
             strategies=None,
             log_level=args.log_level,
+            real_data=real_data,
         )
     elif args.compare:
         _run_compare_cli(
@@ -436,6 +439,7 @@ def cmd_backtest(args: argparse.Namespace) -> None:
             risk_levels=None,
             strategies=getattr(args, "strategies", None),
             log_level=args.log_level,
+            real_data=real_data,
         )
     else:
         _backtest_single(args)
@@ -473,6 +477,7 @@ def _run_compare_cli(
     risk_levels: str | None,
     strategies: str | None,
     log_level: str | None,
+    real_data: bool = False,
 ) -> None:
     """Invoke backtest_compare.run_compare_cli() directly with parameters.
 
@@ -489,6 +494,7 @@ def _run_compare_cli(
         risk_levels=risk_levels,
         strategies=strategies,
         log_level=log_level,
+        real_data=real_data,
     )
 
 
@@ -1697,6 +1703,7 @@ examples:
   revt backtest                               30-day backtest
   revt backtest --compare                     compare all strategies side-by-side
   revt backtest --matrix                      all strategies × all risk levels
+  revt backtest --matrix --real-data          matrix with real API data (any branch)
 
   # API Commands (requires int or prod env — switch to main or tagged commit)
   revt api test                               verify API connection is working
@@ -1847,6 +1854,13 @@ environment detection (run / telegram — not overridable):
         choices=["DEBUG", "INFO", "WARNING", "ERROR"],
         default=None,
         help="Logging level (default: LOG_LEVEL from 1Password config, or INFO)",
+    )
+    p_bt.add_argument(
+        "--real-data",
+        dest="real_data",
+        action="store_true",
+        default=False,
+        help="Use real API data even on a dev branch (feature branch development)",
     )
     p_bt.set_defaults(func=cmd_backtest)
 

--- a/cli/revt.py
+++ b/cli/revt.py
@@ -398,6 +398,11 @@ def cmd_backtest(args: argparse.Namespace) -> None:
 
     _set_env()
 
+    # --real-data: promote to int so settings loads int credentials from 1Password.
+    # Must happen before any deferred import that triggers src.config loading.
+    if getattr(args, "real_data", False):
+        os.environ["ENVIRONMENT"] = "int"
+
     # Validate conflicting flags
     if args.matrix and (args.strategy or args.strategies):
         print("⚠️  Warning: --strategy and --strategies are ignored in --matrix mode")

--- a/cli/utils/backtest_args.py
+++ b/cli/utils/backtest_args.py
@@ -1,0 +1,73 @@
+"""Shared helpers for backtest CLI commands.
+
+Both ``cli/commands/backtest.py`` and ``cli/commands/backtest_compare.py``
+need to resolve effective backtest parameters from CLI args + 1Password
+settings, and create the appropriate API client.  This module holds that
+shared logic to avoid duplication.
+"""
+
+from __future__ import annotations
+
+from decimal import Decimal
+from typing import Any
+
+from src.api import create_api_client
+from src.api.client import RevolutAPIClient
+from src.api.mock_client import MockRevolutAPIClient
+from src.config import settings
+
+
+def resolve_backtest_params(args: Any) -> dict[str, Any]:
+    """Resolve effective backtest parameters from CLI args and 1Password settings.
+
+    CLI flags take priority; missing values fall back to the 1Password-sourced
+    ``settings`` object.
+
+    Args:
+        args: Parsed CLI arguments namespace (or any object with optional
+            ``pairs``, ``capital``, ``days``, and ``interval`` attributes).
+
+    Returns:
+        A dict with the following keys:
+
+        - ``symbols`` (list[str]): Trading pairs to backtest.
+        - ``initial_capital`` (Decimal): Starting capital.
+        - ``effective_days`` (int): Historical look-back window in days.
+        - ``effective_interval`` (int): Candle width in minutes.
+    """
+    raw_pairs = args.pairs if args.pairs else ",".join(settings.trading_pairs)
+    symbols: list[str] = raw_pairs.split(",")
+    initial_capital = Decimal(
+        str(args.capital if args.capital is not None else settings.paper_initial_capital)
+    )
+    effective_days: int = args.days if args.days is not None else settings.backtest_days
+    effective_interval: int = (
+        args.interval if args.interval is not None else settings.backtest_interval
+    )
+    return {
+        "symbols": symbols,
+        "initial_capital": initial_capital,
+        "effective_days": effective_days,
+        "effective_interval": effective_interval,
+    }
+
+
+def create_backtest_api_client(
+    args: Any,
+) -> RevolutAPIClient | MockRevolutAPIClient:
+    """Create the API client appropriate for a backtest run.
+
+    Reads ``real_data`` from *args* (defaults to ``False`` when absent) and
+    forwards it as ``force_real`` to :func:`~src.api.create_api_client`.
+
+    Args:
+        args: Parsed CLI arguments namespace.  May optionally carry a
+            ``real_data`` boolean attribute.
+
+    Returns:
+        A :class:`~src.api.mock_client.MockRevolutAPIClient` for dev
+        environments (unless ``real_data`` is ``True``), or a
+        :class:`~src.api.client.RevolutAPIClient` otherwise.
+    """
+    real_data: bool = getattr(args, "real_data", False)
+    return create_api_client(settings.environment, force_real=real_data)

--- a/docs/DEVELOPER_GUIDE.md
+++ b/docs/DEVELOPER_GUIDE.md
@@ -361,8 +361,8 @@ Backtesting lets you test a strategy on real historical data before using real m
 
 ```bash
 # Run the full strategy × risk matrix (shortcut via just)
-just backtest        # 7-day mock data — fast iteration, any branch
-just backtest-int    # 30-day real data — any branch (requires int credentials)
+just backtest             # 7-day mock data — fast iteration, any branch
+just backtest-real-data   # 7-day real data — any branch (requires int credentials)
 
 # Or run directly:
 

--- a/docs/DEVELOPER_GUIDE.md
+++ b/docs/DEVELOPER_GUIDE.md
@@ -361,8 +361,8 @@ Backtesting lets you test a strategy on real historical data before using real m
 
 ```bash
 # Run the full strategy × risk matrix (shortcut via just)
-just backtest-dev    # 7-day mock data — fast iteration on feature branches
-just backtest-int    # 30-day real data — thorough check on main branch
+just backtest        # 7-day mock data — fast iteration, any branch
+just backtest-int    # 30-day real data — any branch (requires int credentials)
 
 # Or run directly:
 

--- a/justfile
+++ b/justfile
@@ -121,8 +121,8 @@ backtest:
     @uv run revt backtest --matrix --days 7
 
 # Run backtest matrix with real API data (any branch — requires 1Password int credentials)
-backtest-int:
-    @uv run revt backtest --matrix --days 30 --real-data
+backtest-real-data:
+    @uv run revt backtest --matrix --days 7 --real-data
 
 # Generate class diagrams using pyreverse
 diagrams:

--- a/justfile
+++ b/justfile
@@ -116,13 +116,13 @@ check: lint format typecheck security deps-audit test
 env:
     @uv run python -c "from cli.utils.env_detect import detect_env; env = detect_env(); print(f'Current environment: {env}')"
 
-# Run backtest matrix in dev environment (mock API — use on feature branches)
-backtest-dev:
+# Run backtest matrix with mock API (fast, any branch)
+backtest:
     @uv run revt backtest --matrix --days 7
 
-# Run backtest matrix in integration environment (real API, paper mode — use on main branch)
+# Run backtest matrix with real API data (any branch — requires 1Password int credentials)
 backtest-int:
-    @uv run revt backtest --matrix --days 30
+    @uv run revt backtest --matrix --days 30 --real-data
 
 # Generate class diagrams using pyreverse
 diagrams:

--- a/src/api/__init__.py
+++ b/src/api/__init__.py
@@ -13,16 +13,19 @@ from .mock_client import MockRevolutAPIClient
 def create_api_client(
     environment: Environment,
     max_requests_per_minute: int = 60,
+    force_real: bool = False,
 ) -> RevolutAPIClient | MockRevolutAPIClient:
     """Create the appropriate API client for the given environment.
 
     Args:
         environment: The deployment environment (dev, int, prod).
         max_requests_per_minute: Rate limit (only applies to real client).
+        force_real: If True, always return the real client even in dev. Use for
+            backtests that need real market data regardless of current branch.
 
     Returns:
-        MockRevolutAPIClient for dev, RevolutAPIClient for int/prod.
+        MockRevolutAPIClient for dev (unless force_real), RevolutAPIClient for int/prod.
     """
-    if environment == Environment.DEV:
+    if not force_real and environment == Environment.DEV:
         return MockRevolutAPIClient(max_requests_per_minute=max_requests_per_minute)
     return RevolutAPIClient(max_requests_per_minute=max_requests_per_minute)

--- a/tests/unit/test_backtest.py
+++ b/tests/unit/test_backtest.py
@@ -1,0 +1,689 @@
+"""Unit tests for cli/commands/backtest.py — single-strategy backtest CLI."""
+
+from __future__ import annotations
+
+import sys
+from decimal import Decimal
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from cli.commands.backtest import main, run_backtest, setup_logging
+from src.backtest.engine import BacktestResults
+from src.config import RiskLevel, StrategyType
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_asyncio_run_mock(exc=None):
+    """Return a side_effect for asyncio.run that closes the coroutine before optionally raising."""
+
+    def _handler(coro):
+        if hasattr(coro, "close"):
+            coro.close()
+        if exc is not None:
+            raise exc
+
+    return _handler
+
+
+def _make_results(
+    *,
+    final_capital: str = "10500",
+    total_pnl: str = "500",
+    total_fees: str = "9.45",
+    return_pct: float = 5.0,
+    total_trades: int = 12,
+    winning_trades: int = 8,
+    losing_trades: int = 4,
+    win_rate: float = 66.7,
+    profit_factor: float = 2.1,
+    max_drawdown: str = "150",
+    sharpe_ratio: float = 1.35,
+) -> BacktestResults:
+    """Build a BacktestResults with controllable values."""
+    r = BacktestResults()
+    r.initial_capital = Decimal("10000")
+    r.final_capital = Decimal(final_capital)
+    r.total_pnl = Decimal(total_pnl)
+    r.total_fees = Decimal(total_fees)
+    r.total_trades = total_trades
+    r.winning_trades = winning_trades
+    r.losing_trades = losing_trades
+    r.max_drawdown = Decimal(max_drawdown)
+    r.sharpe_ratio = sharpe_ratio
+    if winning_trades > 0 and losing_trades > 0:
+        r.trades = [
+            {"pnl": profit_factor * 100, "side": "buy"},
+            {"pnl": -100, "side": "sell"},
+        ]
+    elif winning_trades > 0:
+        r.trades = [{"pnl": 100, "side": "buy"}]
+    return r
+
+
+def _default_args(**overrides) -> SimpleNamespace:
+    """Return a SimpleNamespace that mimics argparse output with sensible defaults."""
+    defaults: dict = {
+        "strategy": None,
+        "risk": None,
+        "pairs": None,
+        "days": None,
+        "interval": None,
+        "capital": None,
+        "log_level": None,
+        "real_data": False,
+    }
+    defaults.update(overrides)
+    return SimpleNamespace(**defaults)
+
+
+# ---------------------------------------------------------------------------
+# setup_logging
+# ---------------------------------------------------------------------------
+
+
+class TestSetupLogging:
+    """Tests for setup_logging function."""
+
+    @patch("cli.commands.backtest.logger")
+    def test_removes_existing_handlers(self, mock_logger: MagicMock) -> None:
+        """setup_logging removes previous loguru handlers before adding a new one."""
+        setup_logging("INFO")
+        mock_logger.remove.assert_called_once()
+
+    @patch("cli.commands.backtest.logger")
+    def test_adds_stderr_handler(self, mock_logger: MagicMock) -> None:
+        """setup_logging adds exactly one stderr handler."""
+        setup_logging("DEBUG")
+        mock_logger.add.assert_called_once()
+
+    @patch("cli.commands.backtest.logger")
+    def test_handler_level_is_forwarded(self, mock_logger: MagicMock) -> None:
+        """The requested log level is forwarded to the handler."""
+        setup_logging("WARNING")
+        _, kwargs = mock_logger.add.call_args
+        assert kwargs["level"] == "WARNING"
+
+    @patch("cli.commands.backtest.logger")
+    def test_error_level(self, mock_logger: MagicMock) -> None:
+        """setup_logging accepts ERROR level."""
+        setup_logging("ERROR")
+        _, kwargs = mock_logger.add.call_args
+        assert kwargs["level"] == "ERROR"
+
+    @patch("cli.commands.backtest.logger")
+    def test_handler_targets_stderr(self, mock_logger: MagicMock) -> None:
+        """The handler is added to sys.stderr."""
+        setup_logging("INFO")
+        positional_args = mock_logger.add.call_args[0]
+        assert positional_args[0] is sys.stderr
+
+
+# ---------------------------------------------------------------------------
+# run_backtest (async)
+# ---------------------------------------------------------------------------
+
+
+class TestRunBacktest:
+    """Tests for the async run_backtest coroutine."""
+
+    @pytest.mark.asyncio
+    @patch("cli.commands.backtest.DatabasePersistence")
+    @patch("cli.commands.backtest.BacktestEngine")
+    @patch("cli.commands.backtest.create_backtest_api_client")
+    async def test_default_args_use_settings(
+        self,
+        mock_create_api: MagicMock,
+        mock_engine_cls: MagicMock,
+        mock_db_cls: MagicMock,
+    ) -> None:
+        """When all args are None, settings values are used as defaults."""
+        mock_client = AsyncMock()
+        mock_create_api.return_value = mock_client
+
+        mock_db = MagicMock()
+        mock_db.save_backtest_run.return_value = 1
+        mock_db_cls.return_value = mock_db
+
+        mock_engine = MagicMock()
+        results = _make_results()
+        mock_engine.run = AsyncMock(return_value=results)
+        mock_engine_cls.return_value = mock_engine
+
+        args = _default_args()
+        await run_backtest(args)
+
+        # API client lifecycle
+        mock_client.initialize.assert_awaited_once()
+        mock_client.close.assert_awaited_once()
+
+        # Engine should have been created and run once
+        mock_engine_cls.assert_called_once()
+        mock_engine.run.assert_awaited_once()
+
+        # Results should be persisted
+        mock_db.save_backtest_run.assert_called_once()
+
+    @pytest.mark.asyncio
+    @patch("cli.commands.backtest.DatabasePersistence")
+    @patch("cli.commands.backtest.BacktestEngine")
+    @patch("cli.commands.backtest.create_backtest_api_client")
+    async def test_explicit_args_override_settings(
+        self,
+        mock_create_api: MagicMock,
+        mock_engine_cls: MagicMock,
+        mock_db_cls: MagicMock,
+    ) -> None:
+        """Explicit CLI flag values override the 1Password settings defaults."""
+        mock_client = AsyncMock()
+        mock_create_api.return_value = mock_client
+
+        mock_db = MagicMock()
+        mock_db.save_backtest_run.return_value = 7
+        mock_db_cls.return_value = mock_db
+
+        mock_engine = MagicMock()
+        results = _make_results()
+        mock_engine.run = AsyncMock(return_value=results)
+        mock_engine_cls.return_value = mock_engine
+
+        args = _default_args(
+            strategy="momentum",
+            risk="aggressive",
+            pairs="BTC-EUR,ETH-EUR",
+            days=14,
+            interval=15,
+            capital=5000.0,
+        )
+        await run_backtest(args)
+
+        # Engine must be constructed with the strategy and risk from args
+        engine_call_kwargs = mock_engine_cls.call_args[1]
+        assert engine_call_kwargs["strategy_type"] == StrategyType.MOMENTUM
+        assert engine_call_kwargs["risk_level"] == RiskLevel.AGGRESSIVE
+        assert engine_call_kwargs["initial_capital"] == Decimal("5000.0")
+
+        # engine.run must receive the explicit days and interval
+        run_call_kwargs = mock_engine.run.call_args[1]
+        assert run_call_kwargs["symbols"] == ["BTC-EUR", "ETH-EUR"]
+        assert run_call_kwargs["days"] == 14
+        assert run_call_kwargs["interval"] == 15
+
+    @pytest.mark.asyncio
+    @patch("cli.commands.backtest.DatabasePersistence")
+    @patch("cli.commands.backtest.BacktestEngine")
+    @patch("cli.commands.backtest.create_backtest_api_client")
+    async def test_real_data_flag_passed_through(
+        self,
+        mock_create_api: MagicMock,
+        mock_engine_cls: MagicMock,
+        mock_db_cls: MagicMock,
+    ) -> None:
+        """When real_data=True, create_backtest_api_client receives args with that flag."""
+        mock_client = AsyncMock()
+        mock_create_api.return_value = mock_client
+
+        mock_db = MagicMock()
+        mock_db.save_backtest_run.return_value = 2
+        mock_db_cls.return_value = mock_db
+
+        mock_engine = MagicMock()
+        mock_engine.run = AsyncMock(return_value=_make_results())
+        mock_engine_cls.return_value = mock_engine
+
+        args = _default_args(real_data=True)
+        await run_backtest(args)
+
+        # The args object with real_data=True is forwarded to the client factory
+        mock_create_api.assert_called_once_with(args)
+        assert mock_create_api.call_args[0][0].real_data is True
+
+    @pytest.mark.asyncio
+    @patch("cli.commands.backtest.DatabasePersistence")
+    @patch("cli.commands.backtest.BacktestEngine")
+    @patch("cli.commands.backtest.create_backtest_api_client")
+    async def test_saves_results_to_db(
+        self,
+        mock_create_api: MagicMock,
+        mock_engine_cls: MagicMock,
+        mock_db_cls: MagicMock,
+    ) -> None:
+        """run_backtest persists results via DatabasePersistence.save_backtest_run."""
+        mock_client = AsyncMock()
+        mock_create_api.return_value = mock_client
+
+        mock_db = MagicMock()
+        mock_db.save_backtest_run.return_value = 42
+        mock_db_cls.return_value = mock_db
+
+        mock_engine = MagicMock()
+        results = _make_results(
+            final_capital="11000",
+            total_pnl="1000",
+            total_fees="10",
+            return_pct=10.0,
+            total_trades=20,
+            winning_trades=15,
+            losing_trades=5,
+            win_rate=75.0,
+            profit_factor=3.0,
+            max_drawdown="200",
+            sharpe_ratio=1.8,
+        )
+        mock_engine.run = AsyncMock(return_value=results)
+        mock_engine_cls.return_value = mock_engine
+
+        args = _default_args(
+            strategy="breakout",
+            risk="conservative",
+            pairs="BTC-EUR",
+            days=7,
+            interval=60,
+            capital=10000.0,
+        )
+        await run_backtest(args)
+
+        mock_db.save_backtest_run.assert_called_once()
+        call_kwargs = mock_db.save_backtest_run.call_args[1]
+        assert call_kwargs["strategy"] == "breakout"
+        assert call_kwargs["risk_level"] == "conservative"
+        assert call_kwargs["symbols"] == ["BTC-EUR"]
+        assert call_kwargs["days"] == 7
+        assert call_kwargs["interval"] == "60"
+        assert call_kwargs["initial_capital"] == Decimal("10000.0")
+
+        rd = call_kwargs["results"]
+        assert rd["final_capital"] == float(Decimal("11000"))
+        assert rd["total_pnl"] == float(Decimal("1000"))
+        assert rd["total_fees"] == float(Decimal("10"))
+        assert rd["return_pct"] == 10.0
+        assert rd["total_trades"] == 20
+        assert rd["winning_trades"] == 15
+        assert rd["losing_trades"] == 5
+        assert rd["win_rate"] == 75.0
+        assert rd["max_drawdown"] == float(Decimal("200"))
+        assert rd["sharpe_ratio"] == 1.8
+
+    @pytest.mark.asyncio
+    @patch("cli.commands.backtest.DatabasePersistence")
+    @patch("cli.commands.backtest.BacktestEngine")
+    @patch("cli.commands.backtest.create_backtest_api_client")
+    async def test_api_client_closed_when_engine_raises(
+        self,
+        mock_create_api: MagicMock,
+        mock_engine_cls: MagicMock,
+        mock_db_cls: MagicMock,
+    ) -> None:
+        """api_client.close() is called in finally even when BacktestEngine.run raises."""
+        mock_client = AsyncMock()
+        mock_create_api.return_value = mock_client
+        mock_db_cls.return_value = MagicMock()
+
+        mock_engine = MagicMock()
+        mock_engine.run = AsyncMock(side_effect=RuntimeError("engine exploded"))
+        mock_engine_cls.return_value = mock_engine
+
+        args = _default_args()
+        with pytest.raises(RuntimeError, match="engine exploded"):
+            await run_backtest(args)
+
+        # Ensure close was still called despite the exception
+        mock_client.close.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    @patch("cli.commands.backtest.DatabasePersistence")
+    @patch("cli.commands.backtest.BacktestEngine")
+    @patch("cli.commands.backtest.create_backtest_api_client")
+    async def test_api_client_closed_on_success(
+        self,
+        mock_create_api: MagicMock,
+        mock_engine_cls: MagicMock,
+        mock_db_cls: MagicMock,
+    ) -> None:
+        """api_client.close() is called even on a successful run."""
+        mock_client = AsyncMock()
+        mock_create_api.return_value = mock_client
+
+        mock_db = MagicMock()
+        mock_db.save_backtest_run.return_value = 1
+        mock_db_cls.return_value = mock_db
+
+        mock_engine = MagicMock()
+        mock_engine.run = AsyncMock(return_value=_make_results())
+        mock_engine_cls.return_value = mock_engine
+
+        args = _default_args()
+        await run_backtest(args)
+
+        mock_client.close.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    @patch("cli.commands.backtest.DatabasePersistence")
+    @patch("cli.commands.backtest.BacktestEngine")
+    @patch("cli.commands.backtest.create_backtest_api_client")
+    async def test_multiple_pairs_split_correctly(
+        self,
+        mock_create_api: MagicMock,
+        mock_engine_cls: MagicMock,
+        mock_db_cls: MagicMock,
+    ) -> None:
+        """Comma-separated pairs string is split into a list correctly."""
+        mock_client = AsyncMock()
+        mock_create_api.return_value = mock_client
+
+        mock_db = MagicMock()
+        mock_db.save_backtest_run.return_value = 1
+        mock_db_cls.return_value = mock_db
+
+        mock_engine = MagicMock()
+        mock_engine.run = AsyncMock(return_value=_make_results())
+        mock_engine_cls.return_value = mock_engine
+
+        args = _default_args(pairs="BTC-EUR,ETH-EUR,SOL-EUR")
+        await run_backtest(args)
+
+        run_call_kwargs = mock_engine.run.call_args[1]
+        assert run_call_kwargs["symbols"] == ["BTC-EUR", "ETH-EUR", "SOL-EUR"]
+
+    @pytest.mark.asyncio
+    @patch("cli.commands.backtest.DatabasePersistence")
+    @patch("cli.commands.backtest.BacktestEngine")
+    @patch("cli.commands.backtest.create_backtest_api_client")
+    async def test_print_summary_called(
+        self,
+        mock_create_api: MagicMock,
+        mock_engine_cls: MagicMock,
+        mock_db_cls: MagicMock,
+    ) -> None:
+        """results.print_summary() is called after a successful run."""
+        mock_client = AsyncMock()
+        mock_create_api.return_value = mock_client
+
+        mock_db = MagicMock()
+        mock_db.save_backtest_run.return_value = 1
+        mock_db_cls.return_value = mock_db
+
+        mock_engine = MagicMock()
+        results = MagicMock(spec=BacktestResults)
+        results.final_capital = Decimal("10500")
+        results.total_pnl = Decimal("500")
+        results.total_fees = Decimal("9.45")
+        results.return_pct = 5.0
+        results.total_trades = 12
+        results.winning_trades = 8
+        results.losing_trades = 4
+        results.win_rate = 66.7
+        results.profit_factor = 2.1
+        results.max_drawdown = Decimal("150")
+        results.sharpe_ratio = 1.35
+        mock_engine.run = AsyncMock(return_value=results)
+        mock_engine_cls.return_value = mock_engine
+
+        args = _default_args()
+        await run_backtest(args)
+
+        results.print_summary.assert_called_once()
+
+    @pytest.mark.asyncio
+    @patch("cli.commands.backtest.DatabasePersistence")
+    @patch("cli.commands.backtest.BacktestEngine")
+    @patch("cli.commands.backtest.create_backtest_api_client")
+    async def test_initial_capital_uses_decimal(
+        self,
+        mock_create_api: MagicMock,
+        mock_engine_cls: MagicMock,
+        mock_db_cls: MagicMock,
+    ) -> None:
+        """initial_capital passed to engine and DB is a Decimal, never float."""
+        mock_client = AsyncMock()
+        mock_create_api.return_value = mock_client
+
+        mock_db = MagicMock()
+        mock_db.save_backtest_run.return_value = 1
+        mock_db_cls.return_value = mock_db
+
+        mock_engine = MagicMock()
+        mock_engine.run = AsyncMock(return_value=_make_results())
+        mock_engine_cls.return_value = mock_engine
+
+        args = _default_args(capital=7500.0)
+        await run_backtest(args)
+
+        engine_kwargs = mock_engine_cls.call_args[1]
+        assert isinstance(engine_kwargs["initial_capital"], Decimal)
+        assert engine_kwargs["initial_capital"] == Decimal("7500.0")
+
+        db_kwargs = mock_db.save_backtest_run.call_args[1]
+        assert isinstance(db_kwargs["initial_capital"], Decimal)
+
+
+# ---------------------------------------------------------------------------
+# main (argparse entry point)
+# ---------------------------------------------------------------------------
+
+
+class TestMain:
+    """Tests for the main() CLI entry point."""
+
+    @patch("cli.commands.backtest.asyncio.run", side_effect=_make_asyncio_run_mock())
+    @patch("cli.commands.backtest.setup_logging")
+    def test_default_args_no_exception(
+        self, mock_setup: MagicMock, mock_asyncio_run: MagicMock
+    ) -> None:
+        """main() with no CLI args runs without errors."""
+        with patch("sys.argv", ["backtest"]):
+            main()
+        mock_setup.assert_called_once()
+        mock_asyncio_run.assert_called_once()
+
+    @patch("cli.commands.backtest.asyncio.run", side_effect=_make_asyncio_run_mock())
+    @patch("cli.commands.backtest.setup_logging")
+    def test_explicit_strategy_flag(
+        self, mock_setup: MagicMock, mock_asyncio_run: MagicMock
+    ) -> None:
+        """main() parses --strategy and passes it to run_backtest."""
+        with patch("sys.argv", ["backtest", "--strategy", "momentum"]):
+            main()
+        mock_asyncio_run.assert_called_once()
+
+    @patch("cli.commands.backtest.asyncio.run", side_effect=_make_asyncio_run_mock())
+    @patch("cli.commands.backtest.setup_logging")
+    def test_all_flags_parsed(self, mock_setup: MagicMock, mock_asyncio_run: MagicMock) -> None:
+        """main() correctly parses all available flags."""
+        with patch(
+            "sys.argv",
+            [
+                "backtest",
+                "--strategy",
+                "breakout",
+                "--risk",
+                "aggressive",
+                "--pairs",
+                "BTC-EUR",
+                "--days",
+                "14",
+                "--interval",
+                "60",
+                "--capital",
+                "5000",
+                "--log-level",
+                "DEBUG",
+            ],
+        ):
+            main()
+        mock_setup.assert_called_with("DEBUG")
+
+    @patch(
+        "cli.commands.backtest.asyncio.run",
+        side_effect=_make_asyncio_run_mock(KeyboardInterrupt()),
+    )
+    @patch("cli.commands.backtest.setup_logging")
+    def test_keyboard_interrupt_caught_gracefully(
+        self, mock_setup: MagicMock, mock_asyncio_run: MagicMock
+    ) -> None:
+        """KeyboardInterrupt is caught and does not propagate or call sys.exit."""
+        with patch("sys.argv", ["backtest"]):
+            # Should NOT raise
+            main()
+
+    @patch(
+        "cli.commands.backtest.asyncio.run",
+        side_effect=_make_asyncio_run_mock(RuntimeError("unexpected crash")),
+    )
+    @patch("cli.commands.backtest.setup_logging")
+    def test_unhandled_exception_exits_with_1(
+        self, mock_setup: MagicMock, mock_asyncio_run: MagicMock
+    ) -> None:
+        """An unhandled exception triggers sys.exit(1)."""
+        with patch("sys.argv", ["backtest"]):
+            with pytest.raises(SystemExit) as exc_info:
+                main()
+        assert exc_info.value.code == 1
+
+    @patch("cli.commands.backtest.asyncio.run", side_effect=_make_asyncio_run_mock())
+    @patch("cli.commands.backtest.setup_logging")
+    def test_log_level_falls_back_to_settings(
+        self, mock_setup: MagicMock, mock_asyncio_run: MagicMock
+    ) -> None:
+        """When --log-level is omitted, settings.log_level is used."""
+        with patch("sys.argv", ["backtest"]):
+            main()
+        call_arg = mock_setup.call_args[0][0]
+        assert isinstance(call_arg, str)
+
+    @patch("cli.commands.backtest.asyncio.run", side_effect=_make_asyncio_run_mock())
+    @patch("cli.commands.backtest.setup_logging")
+    def test_explicit_log_level_forwarded(
+        self, mock_setup: MagicMock, mock_asyncio_run: MagicMock
+    ) -> None:
+        """Explicit --log-level is forwarded to setup_logging."""
+        with patch("sys.argv", ["backtest", "--log-level", "ERROR"]):
+            main()
+        mock_setup.assert_called_with("ERROR")
+
+
+# ---------------------------------------------------------------------------
+# resolve_backtest_params integration via run_backtest
+# ---------------------------------------------------------------------------
+
+
+class TestResolveBacktestParams:
+    """Verify that resolve_backtest_params logic is exercised correctly in run_backtest."""
+
+    @pytest.mark.asyncio
+    @patch("cli.commands.backtest.DatabasePersistence")
+    @patch("cli.commands.backtest.BacktestEngine")
+    @patch("cli.commands.backtest.create_backtest_api_client")
+    async def test_pairs_none_falls_back_to_settings(
+        self,
+        mock_create_api: MagicMock,
+        mock_engine_cls: MagicMock,
+        mock_db_cls: MagicMock,
+    ) -> None:
+        """When pairs is None, settings.trading_pairs is used."""
+        mock_client = AsyncMock()
+        mock_create_api.return_value = mock_client
+
+        mock_db = MagicMock()
+        mock_db.save_backtest_run.return_value = 1
+        mock_db_cls.return_value = mock_db
+
+        mock_engine = MagicMock()
+        mock_engine.run = AsyncMock(return_value=_make_results())
+        mock_engine_cls.return_value = mock_engine
+
+        args = _default_args(pairs=None)
+        await run_backtest(args)
+
+        run_kwargs = mock_engine.run.call_args[1]
+        # Should be a non-empty list from settings
+        assert isinstance(run_kwargs["symbols"], list)
+        assert len(run_kwargs["symbols"]) > 0
+
+    @pytest.mark.asyncio
+    @patch("cli.commands.backtest.DatabasePersistence")
+    @patch("cli.commands.backtest.BacktestEngine")
+    @patch("cli.commands.backtest.create_backtest_api_client")
+    async def test_capital_none_falls_back_to_settings(
+        self,
+        mock_create_api: MagicMock,
+        mock_engine_cls: MagicMock,
+        mock_db_cls: MagicMock,
+    ) -> None:
+        """When capital is None, settings.paper_initial_capital is used."""
+        mock_client = AsyncMock()
+        mock_create_api.return_value = mock_client
+
+        mock_db = MagicMock()
+        mock_db.save_backtest_run.return_value = 1
+        mock_db_cls.return_value = mock_db
+
+        mock_engine = MagicMock()
+        mock_engine.run = AsyncMock(return_value=_make_results())
+        mock_engine_cls.return_value = mock_engine
+
+        args = _default_args(capital=None)
+        await run_backtest(args)
+
+        engine_kwargs = mock_engine_cls.call_args[1]
+        assert isinstance(engine_kwargs["initial_capital"], Decimal)
+
+    @pytest.mark.asyncio
+    @patch("cli.commands.backtest.DatabasePersistence")
+    @patch("cli.commands.backtest.BacktestEngine")
+    @patch("cli.commands.backtest.create_backtest_api_client")
+    async def test_days_none_falls_back_to_settings(
+        self,
+        mock_create_api: MagicMock,
+        mock_engine_cls: MagicMock,
+        mock_db_cls: MagicMock,
+    ) -> None:
+        """When days is None, settings.backtest_days is used."""
+        mock_client = AsyncMock()
+        mock_create_api.return_value = mock_client
+
+        mock_db = MagicMock()
+        mock_db.save_backtest_run.return_value = 1
+        mock_db_cls.return_value = mock_db
+
+        mock_engine = MagicMock()
+        mock_engine.run = AsyncMock(return_value=_make_results())
+        mock_engine_cls.return_value = mock_engine
+
+        args = _default_args(days=None)
+        await run_backtest(args)
+
+        run_kwargs = mock_engine.run.call_args[1]
+        assert isinstance(run_kwargs["days"], int)
+
+    @pytest.mark.asyncio
+    @patch("cli.commands.backtest.DatabasePersistence")
+    @patch("cli.commands.backtest.BacktestEngine")
+    @patch("cli.commands.backtest.create_backtest_api_client")
+    async def test_interval_none_falls_back_to_settings(
+        self,
+        mock_create_api: MagicMock,
+        mock_engine_cls: MagicMock,
+        mock_db_cls: MagicMock,
+    ) -> None:
+        """When interval is None, settings.backtest_interval is used."""
+        mock_client = AsyncMock()
+        mock_create_api.return_value = mock_client
+
+        mock_db = MagicMock()
+        mock_db.save_backtest_run.return_value = 1
+        mock_db_cls.return_value = mock_db
+
+        mock_engine = MagicMock()
+        mock_engine.run = AsyncMock(return_value=_make_results())
+        mock_engine_cls.return_value = mock_engine
+
+        args = _default_args(interval=None)
+        await run_backtest(args)
+
+        run_kwargs = mock_engine.run.call_args[1]
+        assert isinstance(run_kwargs["interval"], int)

--- a/tests/unit/test_backtest_compare.py
+++ b/tests/unit/test_backtest_compare.py
@@ -300,7 +300,7 @@ class TestRunCompare:
     @pytest.mark.asyncio
     @patch("cli.commands.backtest_compare.DatabasePersistence")
     @patch("cli.commands.backtest_compare.BacktestEngine")
-    @patch("cli.commands.backtest_compare.create_api_client")
+    @patch("cli.utils.backtest_args.create_api_client")
     @patch("cli.commands.backtest_compare._print_comparison_table")
     async def test_with_custom_args(
         self,
@@ -357,7 +357,7 @@ class TestRunCompare:
     @pytest.mark.asyncio
     @patch("cli.commands.backtest_compare.DatabasePersistence")
     @patch("cli.commands.backtest_compare.BacktestEngine")
-    @patch("cli.commands.backtest_compare.create_api_client")
+    @patch("cli.utils.backtest_args.create_api_client")
     @patch("cli.commands.backtest_compare._print_comparison_table")
     async def test_defaults_use_all_strategies(
         self,
@@ -396,7 +396,7 @@ class TestRunCompare:
     @pytest.mark.asyncio
     @patch("cli.commands.backtest_compare.DatabasePersistence")
     @patch("cli.commands.backtest_compare.BacktestEngine")
-    @patch("cli.commands.backtest_compare.create_api_client")
+    @patch("cli.utils.backtest_args.create_api_client")
     @patch("cli.commands.backtest_compare._print_comparison_table")
     async def test_multiple_risk_levels(
         self,
@@ -435,7 +435,7 @@ class TestRunCompare:
     @pytest.mark.asyncio
     @patch("cli.commands.backtest_compare.DatabasePersistence")
     @patch("cli.commands.backtest_compare.BacktestEngine")
-    @patch("cli.commands.backtest_compare.create_api_client")
+    @patch("cli.utils.backtest_args.create_api_client")
     @patch("cli.commands.backtest_compare._print_comparison_table")
     async def test_api_client_closed_on_error(
         self,

--- a/tests/unit/test_mock_api_client.py
+++ b/tests/unit/test_mock_api_client.py
@@ -639,3 +639,11 @@ class TestCreateAPIClient:
 
         client = create_api_client(Environment.PROD)
         assert isinstance(client, RevolutAPIClient)
+
+    def test_force_real_on_dev_returns_real_client(self):
+        """force_real=True bypasses mock even in dev — for real-data backtests on feature branches."""
+        from src.api import create_api_client
+        from src.api.client import RevolutAPIClient
+
+        client = create_api_client(Environment.DEV, force_real=True)
+        assert isinstance(client, RevolutAPIClient)


### PR DESCRIPTION
…ny branch

Adds `--real-data` to `revt backtest` so developers on feature branches can run backtests against the real Revolut API without switching to main. Renames `just backtest-dev` → `just backtest` and updates `just backtest-int` to use `--real-data --days 30`, making it branch-agnostic.