### PR TITLE
fix(cli): add --risk-levels flag to revt backtest --compare

### DIFF
--- a/cli/revt.py
+++ b/cli/revt.py
@@ -441,7 +441,7 @@ def cmd_backtest(args: argparse.Namespace) -> None:
             pairs=args.pairs,
             capital=args.capital,
             risk=args.risk,
-            risk_levels=None,
+            risk_levels=getattr(args, "risk_levels", None),
             strategies=getattr(args, "strategies", None),
             log_level=args.log_level,
             real_data=real_data,
@@ -1840,6 +1840,12 @@ environment detection (run / telegram — not overridable):
         choices=["conservative", "moderate", "aggressive"],
         default=None,
         help="Risk level (default: RISK_LEVEL from 1Password config)",
+    )
+    p_bt.add_argument(
+        "--risk-levels",
+        dest="risk_levels",
+        default=None,
+        help="Comma-separated risk levels for --compare (e.g. conservative,moderate,aggressive)",
     )
     p_bt.add_argument(
         "--pairs",


### PR DESCRIPTION
## Summary

- The backtest CI workflow passes `--risk-levels conservative,moderate,aggressive` to `revt backtest --compare`, but the `revt` parser only accepted `--risk` (single level)
- This caused the workflow to fail with `unrecognized arguments: --risk-levels`
- Added `--risk-levels` to the backtest subparser and wired it through `cmd_backtest` so it reaches `run_compare_cli` (where the argument already existed)

## Test plan

- [x] All pre-commit hooks and tests pass
- [x] Verified `revt backtest --compare --risk-levels conservative,moderate,aggressive` parses correctly
- [x] Trigger the backtest workflow to confirm the CI failure is resolved

🤖 Generated with [Claude Code](https://claude.com/claude-code)